### PR TITLE
Ft get listing data from view and paginate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/django
+
+.idea/
+.idea/workspace.xml

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -14,22 +12,23 @@
     <session id="1351357007">
       <usages-collector id="statistics.lifecycle.project">
         <counts>
-          <entry key="project.closed" value="4" />
+          <entry key="project.closed" value="5" />
           <entry key="project.open.time.1" value="1" />
           <entry key="project.open.time.11" value="1" />
           <entry key="project.open.time.14" value="1" />
           <entry key="project.open.time.16" value="1" />
           <entry key="project.open.time.5" value="1" />
-          <entry key="project.opened" value="5" />
+          <entry key="project.open.time.7" value="1" />
+          <entry key="project.opened" value="6" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.open">
         <counts>
           <entry key="css" value="9" />
-          <entry key="gitignore" value="2" />
-          <entry key="html" value="24" />
+          <entry key="gitignore" value="3" />
+          <entry key="html" value="25" />
           <entry key="png" value="2" />
-          <entry key="py" value="43" />
+          <entry key="py" value="47" />
           <entry key="svg" value="1" />
           <entry key="txt" value="3" />
         </counts>
@@ -37,34 +36,46 @@
       <usages-collector id="statistics.file.types.open">
         <counts>
           <entry key="CSS" value="9" />
-          <entry key="HTML" value="24" />
+          <entry key="HTML" value="25" />
           <entry key="Image" value="2" />
-          <entry key="PLAIN_TEXT" value="5" />
-          <entry key="Python" value="43" />
+          <entry key="PLAIN_TEXT" value="6" />
+          <entry key="Python" value="47" />
           <entry key="SVG" value="1" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.edit">
         <counts>
           <entry key="css" value="388" />
-          <entry key="gitignore" value="13" />
-          <entry key="html" value="2044" />
-          <entry key="py" value="3587" />
-          <entry key="txt" value="7103" />
+          <entry key="gitignore" value="51" />
+          <entry key="html" value="3215" />
+          <entry key="py" value="4039" />
+          <entry key="txt" value="8044" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.edit">
         <counts>
           <entry key="CSS" value="388" />
-          <entry key="HTML" value="2044" />
-          <entry key="PLAIN_TEXT" value="7116" />
-          <entry key="Python" value="3587" />
+          <entry key="HTML" value="3215" />
+          <entry key="PLAIN_TEXT" value="8095" />
+          <entry key="Python" value="4039" />
         </counts>
       </usages-collector>
     </session>
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings/urls.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="506">
+              <caret line="25" column="35" selection-start-line="25" selection-start-column="35" selection-end-line="25" selection-end-column="35" />
+              <folding>
+                <element signature="e#632#664#0" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
           <provider selected="true" editor-type-id="text-editor">
@@ -78,28 +89,10 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings_agents/tests.py">
-          <provider selected="true" editor-type-id="text-editor" />
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
+        <entry file="file://$PROJECT_DIR$/pages/urls.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="296">
-              <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="161">
-              <caret line="7" column="18" selection-start-line="7" selection-start-column="6" selection-end-line="7" selection-end-column="18" />
-              <folding>
-                <element signature="e#0#32#0" expanded="true" />
-                <marker date="1549730596340" expanded="true" signature="290:688" ph="..." />
-              </folding>
+            <state relative-caret-position="92">
+              <caret line="5" column="40" selection-start-line="4" selection-end-line="5" selection-end-column="40" />
             </state>
           </provider>
         </entry>
@@ -107,7 +100,7 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="299">
+            <state relative-caret-position="253">
               <caret line="13" selection-start-line="13" selection-end-line="13" selection-end-column="38" />
               <folding>
                 <element signature="e#0#32#0" expanded="true" />
@@ -132,21 +125,11 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="207">
-              <caret line="9" column="4" selection-start-line="9" selection-start-column="4" selection-end-line="9" selection-end-column="4" />
+            <state relative-caret-position="49">
+              <caret line="10" column="78" selection-start-line="10" selection-start-column="78" selection-end-line="10" selection-end-column="78" />
               <folding>
-                <marker date="1549460584398" expanded="true" signature="84:173" ph="..." />
-                <marker date="1549460584398" expanded="true" signature="196:201" ph="..." />
+                <element signature="e#0#35#0" expanded="true" />
               </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/text.txt">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="439">
-              <caret line="216" column="35" selection-start-line="216" selection-start-column="35" selection-end-line="216" selection-end-column="35" />
             </state>
           </provider>
         </entry>
@@ -154,8 +137,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="279">
-              <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
+            <state relative-caret-position="552">
+              <caret line="26" column="13" selection-start-line="26" selection-start-column="4" selection-end-line="26" selection-end-column="13" />
               <folding>
                 <element signature="e#0#28#0" expanded="true" />
                 <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
@@ -165,10 +148,28 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/templates/admin/base_site.html">
+        <entry file="file://$PROJECT_DIR$/templates/listings/listings.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="253">
-              <caret line="11" column="23" lean-forward="true" selection-start-line="11" selection-start-column="23" selection-end-line="11" selection-end-column="23" />
+            <state relative-caret-position="767">
+              <caret line="122" column="12" lean-forward="true" selection-start-line="122" selection-start-column="12" selection-end-line="122" selection-end-column="12" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/text.txt">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="579">
+              <caret line="238" selection-start-line="238" selection-end-line="238" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/.gitignore">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="393">
+              <caret line="135" column="19" selection-start-line="135" selection-start-column="19" selection-end-line="135" selection-end-column="19" />
             </state>
           </provider>
         </entry>
@@ -199,7 +200,6 @@
       <list>
         <option value="$PROJECT_DIR$/pages/views.py" />
         <option value="$PROJECT_DIR$/pages/urls.py" />
-        <option value="$PROJECT_DIR$/.gitignore" />
         <option value="$PROJECT_DIR$/static/css/all.css" />
         <option value="$PROJECT_DIR$/templates/partials/_footer.html" />
         <option value="$PROJECT_DIR$/templates/pages/index.html" />
@@ -209,12 +209,8 @@
         <option value="$PROJECT_DIR$/templates/listings/search.html" />
         <option value="$PROJECT_DIR$/listings_ad/urls.py" />
         <option value="$PROJECT_DIR$/templates/listings/listing.html" />
-        <option value="$PROJECT_DIR$/templates/listings/listings.html" />
         <option value="$PROJECT_DIR$/templates/partials/_navbar.html" />
         <option value="$PROJECT_DIR$/templates/partials/_topbar.html" />
-        <option value="$PROJECT_DIR$/listings_ad/views.py" />
-        <option value="$PROJECT_DIR$/listings/settings.py" />
-        <option value="$PROJECT_DIR$/listings/urls.py" />
         <option value="$PROJECT_DIR$/listings_agents/models.py" />
         <option value="$PROJECT_DIR$/listings_ad/models.py" />
         <option value="$PROJECT_DIR$/templates/admin/base_site_html.html" />
@@ -222,11 +218,16 @@
         <option value="$PROJECT_DIR$/listings/static/css/admin.css" />
         <option value="$PROJECT_DIR$/listings_ad/admin.py" />
         <option value="$PROJECT_DIR$/listings_agents/admin.py" />
+        <option value="$PROJECT_DIR$/listings/urls.py" />
+        <option value="$PROJECT_DIR$/listings/settings.py" />
+        <option value="$PROJECT_DIR$/templates/listings/listings.html" />
+        <option value="$PROJECT_DIR$/listings_ad/views.py" />
         <option value="$PROJECT_DIR$/text.txt" />
+        <option value="$PROJECT_DIR$/.gitignore" />
       </list>
     </option>
   </component>
-  <component name="ProjectFrameBounds" fullScreen="true">
+  <component name="ProjectFrameBounds" extendedState="6" fullScreen="true">
     <option name="y" value="23" />
     <option name="width" value="1440" />
     <option name="height" value="829" />
@@ -237,6 +238,7 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
+      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
@@ -246,23 +248,12 @@
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
-              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings_ad" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
-              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings_agents" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="External Libraries" type="cb654da1:ExternalLibrariesNode" />
             </path>
           </expand>
           <select />
         </subPane>
       </pane>
-      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -346,13 +337,6 @@
     <entry file="file://$PROJECT_DIR$/pages/admin.py">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/.gitignore">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="253">
-          <caret line="11" column="1" selection-start-line="11" selection-start-column="1" selection-end-line="11" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/static/webfonts/fa-brands-400.svg">
       <provider selected="true" editor-type-id="images" />
     </entry>
@@ -431,20 +415,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/pages/urls.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="92">
-          <caret line="5" column="40" selection-start-line="4" selection-end-line="5" selection-end-column="40" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/templates/listings/listings.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="279">
-          <caret line="23" column="40" selection-start-line="23" selection-start-column="40" selection-end-line="23" selection-end-column="40" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/templates/partials/_footer.html">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="92">
@@ -488,17 +458,48 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/tests.py">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/manage.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="23">
+          <caret line="2" column="10" selection-start-line="2" selection-start-column="10" selection-end-line="2" selection-end-column="10" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/templates/admin/base_site.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="253">
+          <caret line="11" column="23" selection-start-line="11" selection-start-column="23" selection-end-line="11" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="161">
+          <caret line="7" column="18" selection-start-line="7" selection-start-column="6" selection-end-line="7" selection-end-column="18" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="324">
+          <caret line="26" column="17" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/listings/settings.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="3220">
-          <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
+        <state relative-caret-position="966">
+          <caret line="42" column="30" selection-start-line="42" selection-start-column="30" selection-end-line="42" selection-end-column="30" />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/listings/urls.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="506">
-          <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
+          <caret line="25" column="35" selection-start-line="25" selection-start-column="35" selection-end-line="25" selection-end-column="35" />
           <folding>
             <element signature="e#632#664#0" expanded="true" />
           </folding>
@@ -515,8 +516,23 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_agents/tests.py">
-      <provider selected="true" editor-type-id="text-editor" />
+    <entry file="file://$PROJECT_DIR$/pages/urls.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="92">
+          <caret line="5" column="40" selection-start-line="4" selection-end-line="5" selection-end-column="40" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="253">
+          <caret line="13" selection-start-line="13" selection-end-line="13" selection-end-column="38" />
+          <folding>
+            <element signature="e#0#32#0" expanded="true" />
+            <marker date="1549730781838" expanded="true" signature="121:277" ph="..." />
+          </folding>
+        </state>
+      </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
       <provider selected="true" editor-type-id="text-editor">
@@ -528,42 +544,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="207">
-          <caret line="9" column="4" selection-start-line="9" selection-start-column="4" selection-end-line="9" selection-end-column="4" />
-          <folding>
-            <marker date="1549460584398" expanded="true" signature="84:173" ph="..." />
-            <marker date="1549460584398" expanded="true" signature="196:201" ph="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/manage.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="23">
-          <caret line="2" column="10" selection-start-line="2" selection-start-column="10" selection-end-line="2" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/templates/admin/base_site.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="253">
-          <caret line="11" column="23" lean-forward="true" selection-start-line="11" selection-start-column="23" selection-end-line="11" selection-end-column="23" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="296">
-          <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="279">
-          <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
+        <state relative-caret-position="552">
+          <caret line="26" column="13" selection-start-line="26" selection-start-column="4" selection-end-line="26" selection-end-column="13" />
           <folding>
             <element signature="e#0#28#0" expanded="true" />
             <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
@@ -571,32 +555,34 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
+    <entry file="file://$PROJECT_DIR$/templates/listings/listings.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="161">
-          <caret line="7" column="18" selection-start-line="7" selection-start-column="6" selection-end-line="7" selection-end-column="18" />
-          <folding>
-            <element signature="e#0#32#0" expanded="true" />
-            <marker date="1549730596340" expanded="true" signature="290:688" ph="..." />
-          </folding>
+        <state relative-caret-position="767">
+          <caret line="122" column="12" lean-forward="true" selection-start-line="122" selection-start-column="12" selection-end-line="122" selection-end-column="12" />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+    <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="299">
-          <caret line="13" selection-start-line="13" selection-end-line="13" selection-end-column="38" />
+        <state relative-caret-position="49">
+          <caret line="10" column="78" selection-start-line="10" selection-start-column="78" selection-end-line="10" selection-end-column="78" />
           <folding>
-            <element signature="e#0#32#0" expanded="true" />
-            <marker date="1549730781838" expanded="true" signature="121:277" ph="..." />
+            <element signature="e#0#35#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/text.txt">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="439">
-          <caret line="216" column="35" selection-start-line="216" selection-start-column="35" selection-end-line="216" selection-end-column="35" />
+        <state relative-caret-position="579">
+          <caret line="238" selection-start-line="238" selection-end-line="238" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/.gitignore">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="393">
+          <caret line="135" column="19" selection-start-line="135" selection-start-column="19" selection-end-line="135" selection-end-column="19" />
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,12 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/listings/settings.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings/settings.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/listings/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings/urls.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/listings_ad/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_ad/admin.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/listings_ad/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_ad/models.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/listings_agents/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_agents/admin.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/listings_agents/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_agents/models.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/text.txt" beforeDir="false" afterPath="$PROJECT_DIR$/text.txt" afterDir="false" />
     </list>
@@ -28,9 +33,9 @@
         <counts>
           <entry key="css" value="8" />
           <entry key="gitignore" value="2" />
-          <entry key="html" value="22" />
+          <entry key="html" value="23" />
           <entry key="png" value="2" />
-          <entry key="py" value="30" />
+          <entry key="py" value="38" />
           <entry key="svg" value="1" />
           <entry key="txt" value="3" />
         </counts>
@@ -38,10 +43,10 @@
       <usages-collector id="statistics.file.types.open">
         <counts>
           <entry key="CSS" value="8" />
-          <entry key="HTML" value="22" />
+          <entry key="HTML" value="23" />
           <entry key="Image" value="2" />
           <entry key="PLAIN_TEXT" value="5" />
-          <entry key="Python" value="30" />
+          <entry key="Python" value="38" />
           <entry key="SVG" value="1" />
         </counts>
       </usages-collector>
@@ -50,16 +55,16 @@
           <entry key="css" value="9" />
           <entry key="gitignore" value="13" />
           <entry key="html" value="1548" />
-          <entry key="py" value="2531" />
-          <entry key="txt" value="3908" />
+          <entry key="py" value="2891" />
+          <entry key="txt" value="5459" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.edit">
         <counts>
           <entry key="CSS" value="9" />
           <entry key="HTML" value="1548" />
-          <entry key="PLAIN_TEXT" value="3921" />
-          <entry key="Python" value="2531" />
+          <entry key="PLAIN_TEXT" value="5472" />
+          <entry key="Python" value="2891" />
         </counts>
       </usages-collector>
     </session>
@@ -69,8 +74,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings/settings.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="223">
-              <caret line="87" column="1" selection-start-line="79" selection-end-line="87" selection-end-column="1" />
+            <state relative-caret-position="3023">
+              <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
             </state>
           </provider>
         </entry>
@@ -78,8 +83,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings/urls.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="279">
-              <caret line="20" column="19" selection-start-line="20" selection-start-column="19" selection-end-line="20" selection-end-column="19" />
+            <state relative-caret-position="348">
+              <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
               <folding>
                 <element signature="e#632#664#0" expanded="true" />
               </folding>
@@ -88,10 +93,13 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/templates/base_layout.html">
+        <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="437">
-              <caret line="19" column="2" selection-start-line="19" selection-start-column="2" selection-end-line="19" selection-end-column="2" />
+            <state relative-caret-position="184">
+              <caret line="8" column="38" selection-start-line="8" selection-start-column="38" selection-end-line="8" selection-end-column="38" />
+              <folding>
+                <element signature="e#0#28#0" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -99,11 +107,24 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="391">
-              <caret line="17" column="24" selection-start-line="17" selection-start-column="24" selection-end-line="17" selection-end-column="24" />
+            <state relative-caret-position="299">
+              <caret line="13" column="58" lean-forward="true" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
               <folding>
                 <element signature="e#0#28#0" expanded="true" />
-                <marker date="1549450811621" expanded="true" signature="122:526" ph="..." />
+                <marker date="1549484656848" expanded="true" signature="122:525" ph="..." />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="207">
+              <caret line="9" column="4" selection-start-line="9" selection-start-column="4" selection-end-line="9" selection-end-column="4" />
+              <folding>
+                <marker date="1549460584398" expanded="true" signature="84:173" ph="..." />
+                <marker date="1549460584398" expanded="true" signature="196:201" ph="..." />
               </folding>
             </state>
           </provider>
@@ -112,29 +133,21 @@
       <file pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/text.txt">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="416">
-              <caret line="132" column="28" selection-start-line="132" selection-start-column="28" selection-end-line="132" selection-end-column="28" />
+            <state relative-caret-position="424">
+              <caret line="176" column="62" selection-start-line="176" selection-start-column="62" selection-end-line="176" selection-end-column="62" />
             </state>
           </provider>
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
+        <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="299">
-              <caret line="13" column="34" selection-start-line="13" selection-start-column="34" selection-end-line="13" selection-end-column="34" />
+            <state relative-caret-position="92">
+              <caret line="4" column="28" selection-start-line="4" selection-start-column="28" selection-end-line="4" selection-end-column="28" />
               <folding>
-                <element signature="e#0#28#0" expanded="true" />
-                <marker date="1549451248538" expanded="true" signature="165:289" ph="..." />
+                <element signature="e#0#32#0" expanded="true" />
               </folding>
             </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings_agents/migrations/0001_initial.py">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-296" />
           </provider>
         </entry>
       </file>
@@ -175,11 +188,13 @@
         <option value="$PROJECT_DIR$/listings_ad/urls.py" />
         <option value="$PROJECT_DIR$/templates/listings/listing.html" />
         <option value="$PROJECT_DIR$/templates/listings/listings.html" />
-        <option value="$PROJECT_DIR$/listings/urls.py" />
         <option value="$PROJECT_DIR$/templates/partials/_navbar.html" />
         <option value="$PROJECT_DIR$/templates/partials/_topbar.html" />
         <option value="$PROJECT_DIR$/listings_ad/views.py" />
+        <option value="$PROJECT_DIR$/listings_ad/admin.py" />
+        <option value="$PROJECT_DIR$/listings_agents/admin.py" />
         <option value="$PROJECT_DIR$/listings/settings.py" />
+        <option value="$PROJECT_DIR$/listings/urls.py" />
         <option value="$PROJECT_DIR$/listings_agents/models.py" />
         <option value="$PROJECT_DIR$/listings_ad/models.py" />
         <option value="$PROJECT_DIR$/text.txt" />
@@ -207,13 +222,28 @@
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings_agents" type="462c0819:PsiDirectoryNode" />
+              <item name="media" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings_agents" type="462c0819:PsiDirectoryNode" />
-              <item name="migrations" type="462c0819:PsiDirectoryNode" />
+              <item name="media" type="462c0819:PsiDirectoryNode" />
+              <item name="photos" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
+              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
+              <item name="media" type="462c0819:PsiDirectoryNode" />
+              <item name="photos" type="462c0819:PsiDirectoryNode" />
+              <item name="2019" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
+              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
+              <item name="media" type="462c0819:PsiDirectoryNode" />
+              <item name="photos" type="462c0819:PsiDirectoryNode" />
+              <item name="2019" type="462c0819:PsiDirectoryNode" />
+              <item name="02" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
@@ -392,16 +422,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="92">
-          <caret line="5" column="21" selection-start-line="5" selection-start-column="21" selection-end-line="5" selection-end-column="21" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings_ad/apps.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="115">
@@ -413,23 +433,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="92">
           <caret line="5" column="40" selection-start-line="4" selection-end-line="5" selection-end-column="40" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings/urls.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="279">
-          <caret line="20" column="19" selection-start-line="20" selection-start-column="19" selection-end-line="20" selection-end-column="19" />
-          <folding>
-            <element signature="e#632#664#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/templates/listings/listing.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="115">
-          <caret line="5" selection-end-line="5" />
         </state>
       </provider>
     </entry>
@@ -471,55 +474,105 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="299">
-          <caret line="13" column="20" selection-start-line="13" selection-start-column="20" selection-end-line="13" selection-end-column="20" />
-          <folding>
-            <marker date="1549425229440" expanded="true" signature="84:173" ph="..." />
-            <marker date="1549425229440" expanded="true" signature="196:201" ph="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings/settings.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="223">
-          <caret line="87" column="1" selection-start-line="79" selection-end-line="87" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="391">
-          <caret line="17" column="24" selection-start-line="17" selection-start-column="24" selection-end-line="17" selection-end-column="24" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-            <marker date="1549450811621" expanded="true" signature="122:526" ph="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="299">
-          <caret line="13" column="34" selection-start-line="13" selection-start-column="34" selection-end-line="13" selection-end-column="34" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-            <marker date="1549451248538" expanded="true" signature="165:289" ph="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings_agents/migrations/0001_initial.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="-296" />
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/views.py">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="184">
+          <caret line="8" column="38" selection-start-line="8" selection-start-column="38" selection-end-line="8" selection-end-column="38" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/templates/listings/listing.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="115">
+          <caret line="5" selection-end-line="5" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/settings.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="3023">
+          <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="531">
+          <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
+            <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="138">
+          <caret line="6" column="27" selection-start-line="6" selection-start-column="27" selection-end-line="6" selection-end-column="27" />
+          <folding>
+            <element signature="e#0#32#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="92">
+          <caret line="4" column="28" selection-start-line="4" selection-start-column="28" selection-end-line="4" selection-end-column="28" />
+          <folding>
+            <element signature="e#0#32#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/views.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="207">
+          <caret line="9" column="4" selection-start-line="9" selection-start-column="4" selection-end-line="9" selection-end-column="4" />
+          <folding>
+            <marker date="1549460584398" expanded="true" signature="84:173" ph="..." />
+            <marker date="1549460584398" expanded="true" signature="196:201" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="299">
+          <caret line="13" column="58" lean-forward="true" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
+            <marker date="1549484656848" expanded="true" signature="122:525" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/urls.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="348">
+          <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
+          <folding>
+            <element signature="e#632#664#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/text.txt">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="416">
-          <caret line="132" column="28" selection-start-line="132" selection-start-column="28" selection-end-line="132" selection-end-column="28" />
+        <state relative-caret-position="424">
+          <caret line="176" column="62" selection-start-line="176" selection-start-column="62" selection-end-line="176" selection-end-column="62" />
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings/settings.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings/settings.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings/urls.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings_ad/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_ad/admin.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings_ad/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_ad/models.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings_agents/admin.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_agents/admin.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/listings_agents/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/listings_agents/models.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/text.txt" beforeDir="false" afterPath="$PROJECT_DIR$/text.txt" afterDir="false" />
-    </list>
+    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -21,49 +12,50 @@
     <session id="1351357007">
       <usages-collector id="statistics.lifecycle.project">
         <counts>
-          <entry key="project.closed" value="3" />
+          <entry key="project.closed" value="4" />
           <entry key="project.open.time.1" value="1" />
           <entry key="project.open.time.11" value="1" />
+          <entry key="project.open.time.14" value="1" />
           <entry key="project.open.time.16" value="1" />
           <entry key="project.open.time.5" value="1" />
-          <entry key="project.opened" value="4" />
+          <entry key="project.opened" value="5" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.open">
         <counts>
-          <entry key="css" value="8" />
+          <entry key="css" value="9" />
           <entry key="gitignore" value="2" />
-          <entry key="html" value="23" />
+          <entry key="html" value="24" />
           <entry key="png" value="2" />
-          <entry key="py" value="38" />
+          <entry key="py" value="40" />
           <entry key="svg" value="1" />
           <entry key="txt" value="3" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.open">
         <counts>
-          <entry key="CSS" value="8" />
-          <entry key="HTML" value="23" />
+          <entry key="CSS" value="9" />
+          <entry key="HTML" value="24" />
           <entry key="Image" value="2" />
           <entry key="PLAIN_TEXT" value="5" />
-          <entry key="Python" value="38" />
+          <entry key="Python" value="40" />
           <entry key="SVG" value="1" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.edit">
         <counts>
-          <entry key="css" value="9" />
+          <entry key="css" value="388" />
           <entry key="gitignore" value="13" />
-          <entry key="html" value="1548" />
+          <entry key="html" value="2044" />
           <entry key="py" value="2891" />
-          <entry key="txt" value="5459" />
+          <entry key="txt" value="6284" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.edit">
         <counts>
-          <entry key="CSS" value="9" />
-          <entry key="HTML" value="1548" />
-          <entry key="PLAIN_TEXT" value="5472" />
+          <entry key="CSS" value="388" />
+          <entry key="HTML" value="2044" />
+          <entry key="PLAIN_TEXT" value="6297" />
           <entry key="Python" value="2891" />
         </counts>
       </usages-collector>
@@ -74,7 +66,7 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings/settings.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="3023">
+            <state relative-caret-position="3220">
               <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
             </state>
           </provider>
@@ -83,7 +75,7 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings/urls.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="348">
+            <state relative-caret-position="506">
               <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
               <folding>
                 <element signature="e#632#664#0" expanded="true" />
@@ -95,7 +87,7 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="184">
+            <state relative-caret-position="161">
               <caret line="8" column="38" selection-start-line="8" selection-start-column="38" selection-end-line="8" selection-end-column="38" />
               <folding>
                 <element signature="e#0#28#0" expanded="true" />
@@ -105,13 +97,26 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings_agents/tests.py">
+          <provider selected="true" editor-type-id="text-editor" />
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="296">
+              <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="299">
-              <caret line="13" column="58" lean-forward="true" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
+            <state relative-caret-position="276">
+              <caret line="13" column="58" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
               <folding>
                 <element signature="e#0#28#0" expanded="true" />
-                <marker date="1549484656848" expanded="true" signature="122:525" ph="..." />
               </folding>
             </state>
           </provider>
@@ -130,23 +135,20 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="true">
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/text.txt">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="424">
-              <caret line="176" column="62" selection-start-line="176" selection-start-column="62" selection-end-line="176" selection-end-column="62" />
+            <state relative-caret-position="-4046">
+              <caret line="5" lean-forward="true" selection-start-line="5" selection-end-line="5" />
             </state>
           </provider>
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+        <entry file="file://$PROJECT_DIR$/templates/admin/base_site.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="92">
-              <caret line="4" column="28" selection-start-line="4" selection-start-column="28" selection-end-line="4" selection-end-column="28" />
-              <folding>
-                <element signature="e#0#32#0" expanded="true" />
-              </folding>
+            <state relative-caret-position="253">
+              <caret line="11" column="23" lean-forward="true" selection-start-line="11" selection-start-column="23" selection-end-line="11" selection-end-column="23" />
             </state>
           </provider>
         </entry>
@@ -156,8 +158,8 @@
   <component name="FileTemplateManagerImpl">
     <option name="RECENT_TEMPLATES">
       <list>
-        <option value="HTML File" />
         <option value="Python Script" />
+        <option value="HTML File" />
       </list>
     </option>
   </component>
@@ -197,7 +199,10 @@
         <option value="$PROJECT_DIR$/listings/urls.py" />
         <option value="$PROJECT_DIR$/listings_agents/models.py" />
         <option value="$PROJECT_DIR$/listings_ad/models.py" />
+        <option value="$PROJECT_DIR$/templates/admin/base_site_html.html" />
+        <option value="$PROJECT_DIR$/templates/admin/base_site.html" />
         <option value="$PROJECT_DIR$/text.txt" />
+        <option value="$PROJECT_DIR$/listings/static/css/admin.css" />
       </list>
     </option>
   </component>
@@ -222,28 +227,20 @@
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="media" type="462c0819:PsiDirectoryNode" />
+              <item name="listings" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="media" type="462c0819:PsiDirectoryNode" />
-              <item name="photos" type="462c0819:PsiDirectoryNode" />
+              <item name="listings" type="462c0819:PsiDirectoryNode" />
+              <item name="static" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="media" type="462c0819:PsiDirectoryNode" />
-              <item name="photos" type="462c0819:PsiDirectoryNode" />
-              <item name="2019" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
-              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="media" type="462c0819:PsiDirectoryNode" />
-              <item name="photos" type="462c0819:PsiDirectoryNode" />
-              <item name="2019" type="462c0819:PsiDirectoryNode" />
-              <item name="02" type="462c0819:PsiDirectoryNode" />
+              <item name="listings" type="462c0819:PsiDirectoryNode" />
+              <item name="static" type="462c0819:PsiDirectoryNode" />
+              <item name="css" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
@@ -391,13 +388,6 @@
     <entry file="file://$PROJECT_DIR$/listings/wsgi.py">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/manage.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="23">
-          <caret line="2" column="10" selection-start-line="2" selection-start-column="10" selection-end-line="2" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/templates/pages/about.html">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="929">
@@ -447,9 +437,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="92">
           <caret line="4" column="11" selection-start-line="4" selection-start-column="11" selection-end-line="4" selection-end-column="11" />
-          <folding>
-            <element signature="e#106#112#0" expanded="true" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -482,16 +469,6 @@
     <entry file="file://$PROJECT_DIR$/listings_agents/views.py">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="184">
-          <caret line="8" column="38" selection-start-line="8" selection-start-column="38" selection-end-line="8" selection-end-column="38" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/templates/listings/listing.html">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="115">
@@ -499,21 +476,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings/settings.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="3023">
-          <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="531">
           <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-            <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -521,9 +487,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="138">
           <caret line="6" column="27" selection-start-line="6" selection-start-column="27" selection-end-line="6" selection-end-column="27" />
-          <folding>
-            <element signature="e#0#32#0" expanded="true" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -531,8 +494,45 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="92">
           <caret line="4" column="28" selection-start-line="4" selection-start-column="28" selection-end-line="4" selection-end-column="28" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/settings.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="3220">
+          <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/urls.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="506">
+          <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
           <folding>
-            <element signature="e#0#32#0" expanded="true" />
+            <element signature="e#632#664#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="161">
+          <caret line="8" column="38" selection-start-line="8" selection-start-column="38" selection-end-line="8" selection-end-column="38" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/tests.py">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="276">
+          <caret line="13" column="58" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
           </folding>
         </state>
       </provider>
@@ -548,31 +548,31 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_agents/models.py">
+    <entry file="file://$PROJECT_DIR$/manage.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="299">
-          <caret line="13" column="58" lean-forward="true" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="58" />
-          <folding>
-            <element signature="e#0#28#0" expanded="true" />
-            <marker date="1549484656848" expanded="true" signature="122:525" ph="..." />
-          </folding>
+        <state relative-caret-position="23">
+          <caret line="2" column="10" selection-start-line="2" selection-start-column="10" selection-end-line="2" selection-end-column="10" />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings/urls.py">
+    <entry file="file://$PROJECT_DIR$/templates/admin/base_site.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="348">
-          <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
-          <folding>
-            <element signature="e#632#664#0" expanded="true" />
-          </folding>
+        <state relative-caret-position="253">
+          <caret line="11" column="23" lean-forward="true" selection-start-line="11" selection-start-column="23" selection-end-line="11" selection-end-column="23" />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/text.txt">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="424">
-          <caret line="176" column="62" selection-start-line="176" selection-start-column="62" selection-end-line="176" selection-end-column="62" />
+        <state relative-caret-position="-4046">
+          <caret line="5" lean-forward="true" selection-start-line="5" selection-end-line="5" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="296">
+          <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="" />
+    <list default="true" id="054d2b99-9963-4f70-8c78-c2b4beb2fdc1" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -27,7 +29,7 @@
           <entry key="gitignore" value="2" />
           <entry key="html" value="24" />
           <entry key="png" value="2" />
-          <entry key="py" value="40" />
+          <entry key="py" value="43" />
           <entry key="svg" value="1" />
           <entry key="txt" value="3" />
         </counts>
@@ -38,7 +40,7 @@
           <entry key="HTML" value="24" />
           <entry key="Image" value="2" />
           <entry key="PLAIN_TEXT" value="5" />
-          <entry key="Python" value="40" />
+          <entry key="Python" value="43" />
           <entry key="SVG" value="1" />
         </counts>
       </usages-collector>
@@ -47,43 +49,22 @@
           <entry key="css" value="388" />
           <entry key="gitignore" value="13" />
           <entry key="html" value="2044" />
-          <entry key="py" value="2891" />
-          <entry key="txt" value="6284" />
+          <entry key="py" value="3587" />
+          <entry key="txt" value="7103" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.edit">
         <counts>
           <entry key="CSS" value="388" />
           <entry key="HTML" value="2044" />
-          <entry key="PLAIN_TEXT" value="6297" />
-          <entry key="Python" value="2891" />
+          <entry key="PLAIN_TEXT" value="7116" />
+          <entry key="Python" value="3587" />
         </counts>
       </usages-collector>
     </session>
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings/settings.py">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="3220">
-              <caret line="140" column="20" selection-start-line="140" selection-start-column="20" selection-end-line="140" selection-end-column="20" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/listings/urls.py">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="506">
-              <caret line="25" column="66" selection-start-line="25" selection-end-line="25" selection-end-column="66" />
-              <folding>
-                <element signature="e#632#664#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings_ad/urls.py">
           <provider selected="true" editor-type-id="text-editor">
@@ -101,11 +82,37 @@
           <provider selected="true" editor-type-id="text-editor" />
         </entry>
       </file>
-      <file pinned="false" current-in-tab="true">
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="296">
               <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="161">
+              <caret line="7" column="18" selection-start-line="7" selection-start-column="6" selection-end-line="7" selection-end-column="18" />
+              <folding>
+                <element signature="e#0#32#0" expanded="true" />
+                <marker date="1549730596340" expanded="true" signature="290:688" ph="..." />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="299">
+              <caret line="13" selection-start-line="13" selection-end-line="13" selection-end-column="38" />
+              <folding>
+                <element signature="e#0#32#0" expanded="true" />
+                <marker date="1549730781838" expanded="true" signature="121:277" ph="..." />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -135,11 +142,24 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="false">
+      <file pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/text.txt">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-4046">
-              <caret line="5" lean-forward="true" selection-start-line="5" selection-end-line="5" />
+            <state relative-caret-position="439">
+              <caret line="216" column="35" selection-start-line="216" selection-start-column="35" selection-end-line="216" selection-end-column="35" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="279">
+              <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
+              <folding>
+                <element signature="e#0#28#0" expanded="true" />
+                <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -193,16 +213,16 @@
         <option value="$PROJECT_DIR$/templates/partials/_navbar.html" />
         <option value="$PROJECT_DIR$/templates/partials/_topbar.html" />
         <option value="$PROJECT_DIR$/listings_ad/views.py" />
-        <option value="$PROJECT_DIR$/listings_ad/admin.py" />
-        <option value="$PROJECT_DIR$/listings_agents/admin.py" />
         <option value="$PROJECT_DIR$/listings/settings.py" />
         <option value="$PROJECT_DIR$/listings/urls.py" />
         <option value="$PROJECT_DIR$/listings_agents/models.py" />
         <option value="$PROJECT_DIR$/listings_ad/models.py" />
         <option value="$PROJECT_DIR$/templates/admin/base_site_html.html" />
         <option value="$PROJECT_DIR$/templates/admin/base_site.html" />
-        <option value="$PROJECT_DIR$/text.txt" />
         <option value="$PROJECT_DIR$/listings/static/css/admin.css" />
+        <option value="$PROJECT_DIR$/listings_ad/admin.py" />
+        <option value="$PROJECT_DIR$/listings_agents/admin.py" />
+        <option value="$PROJECT_DIR$/text.txt" />
       </list>
     </option>
   </component>
@@ -227,20 +247,12 @@
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings" type="462c0819:PsiDirectoryNode" />
+              <item name="listings_ad" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
               <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings" type="462c0819:PsiDirectoryNode" />
-              <item name="static" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
-              <item name="available_listings" type="462c0819:PsiDirectoryNode" />
-              <item name="listings" type="462c0819:PsiDirectoryNode" />
-              <item name="static" type="462c0819:PsiDirectoryNode" />
-              <item name="css" type="462c0819:PsiDirectoryNode" />
+              <item name="listings_agents" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="available_listings" type="b2602c69:ProjectViewProjectNode" />
@@ -476,27 +488,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="531">
-          <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="138">
-          <caret line="6" column="27" selection-start-line="6" selection-start-column="27" selection-end-line="6" selection-end-column="27" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="92">
-          <caret line="4" column="28" selection-start-line="4" selection-start-column="28" selection-end-line="4" selection-end-column="28" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings/settings.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="3220">
@@ -562,17 +553,50 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/text.txt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-4046">
-          <caret line="5" lean-forward="true" selection-start-line="5" selection-end-line="5" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/listings/static/css/admin.css">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="296">
           <caret line="26" column="17" lean-forward="true" selection-start-line="26" selection-start-column="17" selection-end-line="26" selection-end-column="17" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/models.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="279">
+          <caret line="28" column="22" selection-start-line="28" selection-start-column="22" selection-end-line="28" selection-end-column="22" />
+          <folding>
+            <element signature="e#0#28#0" expanded="true" />
+            <marker date="1549509423424" expanded="true" signature="165:289" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_ad/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="161">
+          <caret line="7" column="18" selection-start-line="7" selection-start-column="6" selection-end-line="7" selection-end-column="18" />
+          <folding>
+            <element signature="e#0#32#0" expanded="true" />
+            <marker date="1549730596340" expanded="true" signature="290:688" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/listings_agents/admin.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="299">
+          <caret line="13" selection-start-line="13" selection-end-line="13" selection-end-column="38" />
+          <folding>
+            <element signature="e#0#32#0" expanded="true" />
+            <marker date="1549730781838" expanded="true" signature="121:277" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/text.txt">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="439">
+          <caret line="216" column="35" selection-start-line="216" selection-start-column="35" selection-end-line="216" selection-end-column="35" />
         </state>
       </provider>
     </entry>

--- a/listings/settings.py
+++ b/listings/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
 ]
 
 MIDDLEWARE = [

--- a/listings/settings.py
+++ b/listings/settings.py
@@ -136,3 +136,6 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'listings/static')
 ]
 
+# Media Folder Settings
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'

--- a/listings/static/css/admin.css
+++ b/listings/static/css/admin.css
@@ -1,0 +1,28 @@
+/** Details of how to update the css of the admin section was gotten by inspecting the dom on google chrome **/
+
+#header {
+    height: 50px;
+    background: #10284e;
+    color: #fff
+}
+
+#branding h1 {
+    color: #fff
+}
+
+a:link,
+a:visited {
+    color: #10284e;
+}
+
+div.breadcrumbs {
+    background: #30caa0;
+}
+
+.module h2, .module caption, .inline-group h2 {
+    background: #30caa0;
+}
+
+.button, input[type=submit], input[type=button], .submit-row input, a.button {
+    background: #10284e;
+}

--- a/listings/urls.py
+++ b/listings/urls.py
@@ -23,4 +23,4 @@ urlpatterns = [
     path('', include('pages.urls')),
     path('listings/', include('listings_ad.urls')),
     path('admin/', admin.site.urls),
-] + static(settings.MEDIA_URL, docuement_root=settings.MEDIA_ROOT) # do this to enable the media show up correcly in the front end
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) # do this to enable the media show up correcly in the front end

--- a/listings/urls.py
+++ b/listings/urls.py
@@ -15,9 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
+
 
 urlpatterns = [
     path('', include('pages.urls')),
     path('listings/', include('listings_ad.urls')),
     path('admin/', admin.site.urls),
-]
+] + static(settings.MEDIA_URL, docuement_root=settings.MEDIA_ROOT) # do this to enable the media show up correcly in the front end

--- a/listings_ad/admin.py
+++ b/listings_ad/admin.py
@@ -1,3 +1,7 @@
 from django.contrib import admin
 
 # Register your models here.
+
+from .models import Listing
+
+admin.site.register(Listing)

--- a/listings_ad/admin.py
+++ b/listings_ad/admin.py
@@ -4,4 +4,21 @@ from django.contrib import admin
 
 from .models import Listing
 
-admin.site.register(Listing)
+
+class ListingAdmin(admin.ModelAdmin):
+    """This class customizes what is being displayed in the admin section"""
+
+    # list what is to be displayed in the admin section under the Model listings
+    list_display = ('id', 'title', 'is_published')
+    # headings that will be click-able as links
+    list_display_links = ('id', 'title')
+    # implement filter by
+    list_filter = ('agent',)
+
+    list_editable = ('is_published',)
+    # number of max items to be displayed per page
+    list_per_page = 5
+    search_fields = ('title', 'price', 'city', 'state')
+
+# remember to add the class here
+admin.site.register(Listing, ListingAdmin)

--- a/listings_ad/models.py
+++ b/listings_ad/models.py
@@ -26,5 +26,5 @@ class Listing(models.Model):
     is_published = models.BooleanField(default=True)
     list_date = models.DateTimeField(default=dt.now, blank=True)
 
-    def __self__(self):
+    def __str__(self):
         return self.title

--- a/listings_ad/views.py
+++ b/listings_ad/views.py
@@ -1,13 +1,27 @@
 from django.shortcuts import render
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
+from .models import Listing
+
 
 # Create your views here.
 
 
 def index(request):
-    return render(request, 'listings/listings.html') # templates/listings/listings.html
+
+    listings = Listing.objects.order_by('-list_date').filter(is_published=True)
+    number_of_listings_per_page = 3
+    paginator = Paginator(listings, number_of_listings_per_page)
+    page = request.GET.get('page')
+    paged_listings = paginator.get_page(page)
+
+    context = {
+        "listings": paged_listings
+    }
+    return render(request, 'listings/listings.html', context) # templates/listings/listings.html
 
 
-def listing(request):
+# ensure to pass the id if passed in the urls.py
+def listing(request, listing_id):
     return render(request, 'listings/listing.html')
 
 

--- a/listings_agents/admin.py
+++ b/listings_agents/admin.py
@@ -2,5 +2,13 @@ from django.contrib import admin
 
 from .models import Agent
 
+# set up the model admin
+class AgentAdmin(admin.ModelAdmin):
+    list_display = ('id', 'name', 'email')
+    list_display_links = ('id', 'name')
+    search_fields = ('name', 'email', 'phone')
+    list_per_page = 10
+
+
 # Register your models here.
-admin.site.register(Agent)
+admin.site.register(Agent, AgentAdmin)

--- a/listings_agents/admin.py
+++ b/listings_agents/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
+from .models import Agent
+
 # Register your models here.
+admin.site.register(Agent)

--- a/listings_agents/models.py
+++ b/listings_agents/models.py
@@ -14,6 +14,6 @@ class Agent(models.Model):
     photo = models.ImageField(upload_to='photos/%Y/%m/%d')
     hire_date = models.DateTimeField(default=dt.now, blank=True)
 
-    def __self__(self):
+    def __str__(self):
         return self.name
 

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,19 @@
+<!--note that the name of this file must be base_site.html-->
+<!--in order to customize the admin section we must extend admin/base.html-->
+<!--even though it doesn't exist anywhere or we cant see it-->
+{% extends 'admin/base.html' %}
+
+<!--because we need to make use of the static files-->
+{% load static %}
+
+<!--for the logo-->
+{% block branding %}
+<h1 id="head">
+    Availaible Listings
+</h1>
+{% endblock %}
+<!--end of log part-->
+
+{% block extrastyle %}
+<link rel="stylesheet" href="{% static 'css/admin.css' %}">
+{% endblock %}

--- a/templates/listings/listings.html
+++ b/templates/listings/listings.html
@@ -1,4 +1,5 @@
 {% extends 'base_layout.html' %}
+{% load humanize %}
 
 {% block content %}
 
@@ -34,285 +35,90 @@
     <div class="container">
       <div class="row">
 
-        <!-- Listing 1 -->
+        {% if listings %}
+        {% for listing in listings %}
         <div class="col-md-6 col-lg-4 mb-4">
           <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-1.jpg" alt="">
+            <img class="card-img-top" src="{{ listing.main_photo.url }}" alt="">
             <div class="card-img-overlay">
               <h2>
-                <span class="badge badge-secondary text-white">$490,000</span>
+                <span class="badge badge-secondary text-white">N{{listing.price | intcomma }}</span>
               </h2>
             </div>
             <div class="card-body">
               <div class="listing-heading text-center">
-                <h4 class="text-primary">45 Drivewood Circle</h4>
+                <h4 class="text-primary">{{listing.address}}</h4>
                 <p>
-                  <i class="fas fa-map-marker text-secondary"></i> Norwood MA, 02062</p>
+                  <i class="fas fa-map-marker text-secondary"></i>{{listing.city}} {{listing.state}}</p>
               </div>
               <hr>
               <div class="row py-2 text-secondary">
                 <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 3200</div>
+                  <i class="fas fa-th-large"></i> Sqft: N/A</div>
                 <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 2</div>
+                  <i class="fas fa-car"></i> Garage: Yes</div>
               </div>
               <div class="row py-2 text-secondary">
                 <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 3</div>
+                  <i class="fas fa-bed"></i> Bedrooms: {{ listing.bedrooms}}</div>
                 <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 2</div>
+                  <i class="fas fa-bath"></i> Bathrooms: {{listing.bathrooms}}</div>
               </div>
               <hr>
               <div class="row py-2 text-secondary">
                 <div class="col-12">
-                  <i class="fas fa-user"></i> Kyle Brown</div>
+                  <i class="fas fa-user"></i> {{listing.agent}}</div>
               </div>
               <div class="row text-secondary pb-2">
                 <div class="col-6">
-                  <i class="fas fa-clock"></i> 2 days ago</div>
+                  <i class="fas fa-clock"></i> {{listing.list_date | naturaltime}}</div>
               </div>
               <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
+              <a href="{% url 'listing' listing.id %}" class="btn btn-primary btn-block">More Info</a>
             </div>
           </div>
         </div>
-
-        <!-- Listing 2 -->
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-2.jpg" alt="">
-            <div class="card-img-overlay">
-              <h2>
-                <span class="badge badge-secondary text-white">$550,000</span>
-              </h2>
-            </div>
-            <div class="card-body">
-              <div class="listing-heading text-center">
-                <h4 class="text-primary">18 Jefferson Lane</h4>
-                <p>
-                  <i class="fas fa-map-marker text-secondary"></i> Woburn MA, 01801</p>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 3200</div>
-                <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 1</div>
-              </div>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 4</div>
-                <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 2.5</div>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-user"></i> Mark Hudson</div>
-              </div>
-              <div class="row text-secondary pb-2">
-                <div class="col-6">
-                  <i class="fas fa-clock"></i> 5 days ago</div>
-              </div>
-              <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Listing 3 -->
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-3.jpg" alt="">
-            <div class="card-img-overlay">
-              <h2>
-                <span class="badge badge-secondary text-white">$580,000</span>
-              </h2>
-            </div>
-            <div class="card-body">
-              <div class="listing-heading text-center">
-                <h4 class="text-primary">187 Woodrow Street</h4>
-                <p>
-                  <i class="fas fa-map-marker text-secondary"></i> Salem MA, 01915</p>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 3107</div>
-                <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 0</div>
-              </div>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 4</div>
-                <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 3</div>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-user"></i> Mark Hudson</div>
-              </div>
-              <div class="row text-secondary pb-2">
-                <div class="col-6">
-                  <i class="fas fa-clock"></i> 5 days ago</div>
-              </div>
-              <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Listing 4 -->
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-4.jpg" alt="">
-            <div class="card-img-overlay">
-              <h2>
-                <span class="badge badge-secondary text-white">$380,000</span>
-              </h2>
-            </div>
-            <div class="card-body">
-              <div class="listing-heading text-center">
-                <h4 class="text-primary">28 Gifford Street</h4>
-                <p>
-                  <i class="fas fa-map-marker text-secondary"></i> Bedford NH, 03103</p>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 2927</div>
-                <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 2</div>
-              </div>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 4</div>
-                <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 2</div>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-user"></i> Jenny Johnson</div>
-              </div>
-              <div class="row text-secondary pb-2">
-                <div class="col-6">
-                  <i class="fas fa-clock"></i> 5 days ago</div>
-              </div>
-              <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Listing 5 -->
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-5.jpg" alt="">
-            <div class="card-img-overlay">
-              <h2>
-                <span class="badge badge-secondary text-white">$230,000</span>
-              </h2>
-            </div>
-            <div class="card-body">
-              <div class="listing-heading text-center">
-                <h4 class="text-primary">12 United Road</h4>
-                <p>
-                  <i class="fas fa-map-marker text-secondary"></i> South Hampton NH, 03827</p>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 2207</div>
-                <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 1</div>
-              </div>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 3</div>
-                <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 1.5</div>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-user"></i> Kyle Brown</div>
-              </div>
-              <div class="row text-secondary pb-2">
-                <div class="col-6">
-                  <i class="fas fa-clock"></i> 5 days ago</div>
-              </div>
-              <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Listing 6 -->
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card listing-preview">
-            <img class="card-img-top" src="assets/img/homes/home-6.jpg" alt="">
-            <div class="card-img-overlay">
-              <h2>
-                <span class="badge badge-secondary text-white">$780,000</span>
-              </h2>
-            </div>
-            <div class="card-body">
-              <div class="listing-heading text-center">
-                <h4 class="text-primary">33 Essex Circle</h4>
-                <p>
-                  <i class="fas fa-map-marker text-secondary"></i> Lexington MA, 01731</p>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-th-large"></i> Sqft: 4145</div>
-                <div class="col-6">
-                  <i class="fas fa-car"></i> Garage: 1</div>
-              </div>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-bed"></i> Bedrooms: 5</div>
-                <div class="col-6">
-                  <i class="fas fa-bath"></i> Bathrooms: 3.5</div>
-              </div>
-              <hr>
-              <div class="row py-2 text-secondary">
-                <div class="col-6">
-                  <i class="fas fa-user"></i> Kyle Brown</div>
-              </div>
-              <div class="row text-secondary pb-2">
-                <div class="col-6">
-                  <i class="fas fa-clock"></i> 5 days ago</div>
-              </div>
-              <hr>
-              <a href="listing.html" class="btn btn-primary btn-block">More Info</a>
-            </div>
-          </div>
-        </div>
+        {% endfor %}
+        {% else %}
+          <div class="col-md-12"><p>No listings  </p></div>
+        {% endif %}
+        <!-- Listing 1 -->
 
       </div>
 
       <div class="row">
         <div class="col-md-12">
-          <ul class="pagination">
-            <li class="page-item disabled">
-              <a class="page-link" href="#">&laquo;</a>
-            </li>
-            <li class="page-item active">
-              <a class="page-link" href="#">1</a>
-            </li>
-            <li class="page-item">
-              <a class="page-link" href="#">2</a>
-            </li>
-            <li class="page-item">
-              <a class="page-link" href="#">3</a>
-            </li>
-            <li class="page-item">
-              <a class="page-link" href="#">&raquo;</a>
-            </li>
-          </ul>
+            {% if listings.has_other_pages %}
+                  <ul class="pagination">
+                    {% if listings.has_previous %}
+                        <li class="page-item">
+                            <a href="?page={{ listings.previous_page_number}}" class="page-link">Previous</a>
+                        </li>
+                    {% else %}
+                      <li class="page-item page-link disabled"><a>Previous</a></li>
+                    {% endif %}
+
+                  {% for i in listings.paginator.page_range %}
+                      {% if listings.number == i %}
+                        <li class="page-item active">
+                            <a class="page-link">{{i}}</a>
+                        </li>
+                      {% else %}
+                          <li class="page-item">
+                                <a href="?page={{i}}" class="page-link">{{i}}</a>
+                          </li>
+                      {% endif %}
+                  {% endfor %}
+                  {% if listings.has_next %}
+                        <li class="page-item">
+                            <a href="?page={{ listings.next_page_number }}" class="page-link">Next</a>
+                        </li>
+                  {% else %}
+                      <li class="page-item page-link disabled"><a>Next</a></li>
+
+                  {% endif %}
+                  </ul>
+            {% endif %}
         </div>
       </div>
     </div>

--- a/text.txt
+++ b/text.txt
@@ -215,3 +215,24 @@ this references what ever the static folder is, that is defined in the settings 
       like, list_filter, search, list_likns etc
 
 37. Do the same for the agent class
+
+38. Update the html page (listing.html)
+    also note that the images are showing due to the earlier configuration made in 31 - 33
+    the image can also be gotten as a url
+    eg -  http://127.0.0.1:8000/media/photos/yyyy/mm/dd/imageName.jpg
+
+39. Add humanize to the base app settings.py (int the installed apps)
+    ie listings/settings.py
+            installed_apps = [django.contrib.humanize]
+
+40. use the Intcomma feature of humanize to add comma to the value of the price of the flat
+    note that humanize has other feature, check the documentation for more
+
+    in the layout page ie listings.html
+    {% load humanize %}
+    view the docs for more details
+    remember to always pipe the output with the required humanize filter.
+    ie {{listings.price | intcomma }}
+
+41. Add pagination to listings page
+    using the django pajinator, you can read the docs for more info

--- a/text.txt
+++ b/text.txt
@@ -195,3 +195,23 @@ this references what ever the static folder is, that is defined in the settings 
     - the ids and classes etc to be edited were known by inspecting the admin page on chrome to see the documents / dom
         elements
     -
+
+36. Update the admin functionality for each model
+    Remember that models belongs to various app
+    for instance the Agent model belongs to the listing_agent app
+    and the Listing model belongs to the listing app
+    an app can have mulitple models
+
+    But as long as that app/model has been registered to the admin
+    its model can be accessed in the /admin page
+    This is where we want to customize its functionality
+
+    - listings_ad /admin.py
+    - create a class with an arbitrary name eg "ListingAdmin"
+    - the class must inherit admin.Modeladmin
+    - remeber to add the class as part of
+        admin.site.register(ClassName, register_it_here)
+    - update the class with the requirements to be included
+      like, list_filter, search, list_likns etc
+
+37. Do the same for the agent class

--- a/text.txt
+++ b/text.txt
@@ -1,6 +1,14 @@
+I would like to give nomenclature to folder
+available_listings -> this is the base project folder
+            listings -> this is the base application / app folder
+                listings_ad -> subsequent app
+                listing_agents -> subsequent app
+
 ****
 create an applciation
 ****
+django-admin startproject <name_of_project>
+
 1 . python manage.py startapp <app_name>
 2. Add PagesConfig from pages/apps in the listing settings apps area,
     this enable the pages application to be recognized
@@ -175,3 +183,15 @@ this references what ever the static folder is, that is defined in the settings 
         it saves the photos in available_listings/media/photos/year/month/day
         This is similar to how we configured the media to be saved in the models
         photo = models.ImageField(upload_to='photos/%Y/%m/%d')
+
+
+35 . ***** Changing the look and feel of the admin template ******
+    - in templates folder
+    - create a folder "admin"
+    - create a base_site.html file in the folder
+    - extend admin/base.html
+    - add admin.css in listings/static/css/admin.css, ie in the base application folder folder, not the base project folder
+    - add css
+    - the ids and classes etc to be edited were known by inspecting the admin page on chrome to see the documents / dom
+        elements
+    -

--- a/text.txt
+++ b/text.txt
@@ -132,3 +132,46 @@ this references what ever the static folder is, that is defined in the settings 
 
 28. Migrate the changes to the database
     python manage.py migrate
+
+29. Create a super user (Admin user)
+        check help with "python manage.py help" you can see the "createsuperuser" command
+        -
+        python manage.py createsuperuser
+        enter email
+        enter password
+
+30 . Register models in admin section for each application
+    eg. available_listings/listings_ad(theapp)/admin.py
+      register the model there
+      this will enable the admin to be able to perform CRUD operations on the model from
+      localhost:8000/admin or thesite/admin
+      note that you must register models in each app if you want them to be shown in the admin section
+
+      - available_listings/listings_ad(theapp)/admin.py
+      - import the model from the models of the application
+      - register the model
+        admin.site.register(model_name)
+      - go to /admin and you will see the model has been added to the admin section
+
+    Register the Agent model in the admin.py of the listing_agent app
+
+31. Media folder
+    in the base application, listings
+    - settings.py
+
+    - Add the Media Folder settings
+    # Media Folder Settings
+    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+    MEDIA_URL = '/media/'
+
+ 32. inorder to show the media
+    in listings/urls.py append with + the MEDIA locations from the settings.py
+
+    ] + static(settings.MEDIA_URL, docuement_root=settings.MEDIA_ROOT)
+    # this enables the media files to show up in the front end
+
+ 33. After configuring the media path ie (31 & 32) it creates a media folder in the root of the application
+        When media (photos) files are added in the application by the admin,
+        it saves the photos in available_listings/media/photos/year/month/day
+        This is similar to how we configured the media to be saved in the models
+        photo = models.ImageField(upload_to='photos/%Y/%m/%d')


### PR DESCRIPTION
#### What does this PR do?
- Create a superuser
- Setup media folder
- Update the admin css (colour theme)
- Change the admin button
- Update admin panel functionality
- Get listings from view
- Paginates the listings

#### Description of Task to be completed?
Have the following endpoints working for admin
- Login as an admin to view changes in admin section

Have the following endpoints working for user
- GET /listings
- Get /listings?page=<page_number>

#### How should this be manually tested?
- Clone the repo git clone https://github.com/klevamane/available-listings.git
- Setup virtual environment
- run `pip install`
- Start server with `python manage.py runserver`
- checkout into the branch `ft-get-listing-data-from-view-and-paginate`


 In postman navigate to `http://localhost:8000`
  
#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
N/A

